### PR TITLE
Delete movie method fix

### DIFF
--- a/RadarrSharp/Endpoints/Movie/Movie.cs
+++ b/RadarrSharp/Endpoints/Movie/Movie.cs
@@ -140,7 +140,7 @@ namespace RadarrSharp.Endpoints.Movie
                 { "deleteFiles", deleteFiles }
             };
 
-            await _radarrClient.Delete($"/movie/id={id}{ParameterHelper.BuildParameterString(param)}");
+            await _radarrClient.Delete($"/movie/{id}{ParameterHelper.BuildParameterString(param)}");
         }
 
         /// <summary>

--- a/RadarrSharp/RadarrClient.cs
+++ b/RadarrSharp/RadarrClient.cs
@@ -356,12 +356,12 @@ namespace RadarrSharp
             using (var httpClient = new HttpClient { BaseAddress = new Uri(ApiUrl) })
             {
                 httpClient.DefaultRequestHeaders.Add("X-Api-Key", ApiKey);
-                httpClient.DefaultRequestHeaders.Add("Content-Type", "application/json");
+                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 httpClient.DefaultRequestHeaders.Add("User-Agent", $"{Assembly.GetExecutingAssembly().GetName().Name.Replace(" ", ".")}.v{Assembly.GetExecutingAssembly().GetName().Version}");
 
                 try
                 {
-                    await httpClient.DeleteAsync(endpointUrl);
+                    await httpClient.DeleteAsync($"{ApiUrl}{endpointUrl}");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Deleting a movie would cause the following error:
`Misused header name. Make sure request headers are used with  HttpRequestMessage, response headers with HttpResponseMessage, and content headers with HttpContent objects.`
This was fixed in this pull request.

`http.client.deleteasync` paramater was missing the `ApiUrl` variable. Due to this, the movie was not being deleted.